### PR TITLE
Added DPD signatures

### DIFF
--- a/scripts/icsnpp/enip/__load__.zeek
+++ b/scripts/icsnpp/enip/__load__.zeek
@@ -1,1 +1,2 @@
+@load-sigs ./dpd.sig
 @load ./main

--- a/scripts/icsnpp/enip/dpd.sig
+++ b/scripts/icsnpp/enip/dpd.sig
@@ -1,0 +1,14 @@
+# These signatures have not been thoroughly tested.
+
+signature dpd_enip_tcp_client {
+  ip-proto == tcp
+  payload /^\x65\x00.{2}.{4}\x00{4}/
+}
+
+signature dpd_enip_tcp_server {
+  ip-proto == tcp
+  payload /^\x65\x00/
+  requires-signature dpd_enip_tcp_client
+  enable "ENIP_TCP"
+}
+


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Added Added preliminary DPD signatures to enable to analyzer

## 💭 Motivation and context ##

In case users aren't sure which port numbers to expect ENIP traffic to appear on, DPD will enable the analyzer dynamically based on packet contents.

## 🧪 Testing ##

I used the trace files named `ettercap.pcap` and `HMI2PLC.pcap` from the USCC resources [found here](https://uscc.cyberquests.org/assets/cyberquest_spring2021.zip).

