### PR TITLE
Zeek v4.1 compatibility

### DIFF
--- a/src/ENIP.cc
+++ b/src/ENIP.cc
@@ -1,85 +1,85 @@
 // Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
 
 #include "ENIP.h"
-#include "analyzer/protocol/tcp/TCP_Reassembler.h"
-#include "Reporter.h"
+#include <zeek/analyzer/protocol/tcp/TCP_Reassembler.h>
+#include <zeek/Reporter.h>
 #include "events.bif.h"
 
-using namespace analyzer::enip;
+namespace zeek::analyzer::enip {
+  ENIP_TCP_Analyzer::ENIP_TCP_Analyzer(Connection* c): analyzer::tcp::TCP_ApplicationAnalyzer("ENIP_TCP", c)
+  {
+      interp = new binpac::ENIP::ENIP_Conn(this);
+      had_gap = false;
+  }
 
-ENIP_TCP_Analyzer::ENIP_TCP_Analyzer(Connection* c): tcp::TCP_ApplicationAnalyzer("ENIP_TCP", c) 
-{
-    interp = new binpac::ENIP::ENIP_Conn(this);
-    had_gap = false;
-}
+  ENIP_TCP_Analyzer::~ENIP_TCP_Analyzer()
+  {
+      delete interp;
+  }
 
-ENIP_TCP_Analyzer::~ENIP_TCP_Analyzer() 
-{
-    delete interp;
-}
+  void ENIP_TCP_Analyzer::Done()
+  {
+      analyzer::tcp::TCP_ApplicationAnalyzer::Done();
+      interp->FlowEOF(true);
+      interp->FlowEOF(false);
+  }
 
-void ENIP_TCP_Analyzer::Done() 
-{
-    tcp::TCP_ApplicationAnalyzer::Done();
-    interp->FlowEOF(true);
-    interp->FlowEOF(false);
-}
+  void ENIP_TCP_Analyzer::EndpointEOF(bool is_orig)
+  {
+      analyzer::tcp::TCP_ApplicationAnalyzer::EndpointEOF(is_orig);
+      interp->FlowEOF(is_orig);
+  }
 
-void ENIP_TCP_Analyzer::EndpointEOF(bool is_orig) 
-{
-    tcp::TCP_ApplicationAnalyzer::EndpointEOF(is_orig);
-    interp->FlowEOF(is_orig);
-}
+  void ENIP_TCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
+  {
+      analyzer::tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
+      assert(TCP());
+      if(had_gap)
+          return;
 
-void ENIP_TCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
-{
-    tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
-    assert(TCP());
-    if(had_gap)
-        return;
+      try
+      {
+          interp->NewData(orig, data, data + len);
+      }
+      catch(const binpac::Exception& e)
+      {
+          ProtocolViolation(util::fmt("Binpac exception: %s", e.c_msg()));
+      }
+  }
 
-    try 
-    {
-        interp->NewData(orig, data, data + len);
-    }
-    catch(const binpac::Exception& e) 
-    {
-        ProtocolViolation(fmt("Binpac exception: %s", e.c_msg()));
-    }
-}
+  void ENIP_TCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
+  {
+      analyzer::tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
+      had_gap = true;
+      interp->NewGap(orig, len);
+  }
 
-void ENIP_TCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig) 
-{
-    tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
-    had_gap = true;
-    interp->NewGap(orig, len);
-}
+  ENIP_UDP_Analyzer::ENIP_UDP_Analyzer(Connection* c): analyzer::Analyzer("ENIP_UDP", c)
+  {
+      interp = new binpac::ENIP::ENIP_Conn(this);
+  }
 
-ENIP_UDP_Analyzer::ENIP_UDP_Analyzer(Connection* c): analyzer::Analyzer("ENIP_UDP", c)
-{
-    interp = new binpac::ENIP::ENIP_Conn(this);
-}
+  ENIP_UDP_Analyzer::~ENIP_UDP_Analyzer()
+  {
+      delete interp;
+  }
 
-ENIP_UDP_Analyzer::~ENIP_UDP_Analyzer() 
-{
-    delete interp;
-}
+  void ENIP_UDP_Analyzer::Done()
+  {
+      zeek::analyzer::Analyzer::Done();
+  }
 
-void ENIP_UDP_Analyzer::Done()
-{
-    Analyzer::Done();
-}
+  void ENIP_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const zeek::IP_Hdr* ip, int caplen)
+  {
+      zeek::analyzer::Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 
-void ENIP_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
-{
-    Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
-
-    try
-    {
-        interp->NewData(orig, data, data + len);
-    }
-    catch ( const binpac::Exception& e )
-    {
-        ProtocolViolation(fmt("Binpac exception: %s", e.c_msg()));
-    }
+      try
+      {
+          interp->NewData(orig, data, data + len);
+      }
+      catch ( const binpac::Exception& e )
+      {
+          ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+      }
+  }
 }

--- a/src/ENIP.h
+++ b/src/ENIP.h
@@ -3,7 +3,11 @@
 #pragma once
 
 #include <zeek/analyzer/protocol/tcp/TCP.h>
+#if ZEEK_VERSION_NUMBER >= 40100
 #include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
+#else
+#include <zeek/analyzer/protocol/udp/UDP.h>
+#endif
 
 #include "enip_pac.h"
 

--- a/src/ENIP.h
+++ b/src/ENIP.h
@@ -1,59 +1,52 @@
 // Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
 
-#ifndef ANALYZER_PROTOCOL_ENIP_H
-#define ANALYZER_PROTOCOL_ENIP_H
+#pragma once
 
-#include "analyzer/protocol/tcp/TCP.h"
-#include "analyzer/protocol/udp/UDP.h"
+#include <zeek/analyzer/protocol/tcp/TCP.h>
+#include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
 
 #include "enip_pac.h"
 
-namespace analyzer 
-{ 
-    namespace enip 
-    {
-        class ENIP_TCP_Analyzer : public tcp::TCP_ApplicationAnalyzer 
-        {
-            public:
-                ENIP_TCP_Analyzer(Connection* conn);
-                virtual ~ENIP_TCP_Analyzer();
+namespace zeek::analyzer::enip {
+  class ENIP_TCP_Analyzer : public analyzer::tcp::TCP_ApplicationAnalyzer
+  {
+      public:
+          ENIP_TCP_Analyzer(Connection* conn);
+          virtual ~ENIP_TCP_Analyzer();
 
-                virtual void Done();
-                virtual void DeliverStream(int len, const u_char* data, bool orig);
-                virtual void Undelivered(uint64_t seq, int len, bool orig);
+          virtual void Done();
+          virtual void DeliverStream(int len, const u_char* data, bool orig);
+          virtual void Undelivered(uint64_t seq, int len, bool orig);
 
-                virtual void EndpointEOF(bool is_orig);
+          virtual void EndpointEOF(bool is_orig);
 
-                static analyzer::Analyzer* Instantiate(Connection* conn) 
-                { 
-                    return new ENIP_TCP_Analyzer(conn);
-                }
+          static analyzer::Analyzer* Instantiate(Connection* conn)
+          {
+              return new ENIP_TCP_Analyzer(conn);
+          }
 
-            protected:
-                binpac::ENIP::ENIP_Conn* interp;
-                bool had_gap;
-        };
+      protected:
+          binpac::ENIP::ENIP_Conn* interp;
+          bool had_gap;
+  };
 
-        class ENIP_UDP_Analyzer : public analyzer::Analyzer 
-        {
+  class ENIP_UDP_Analyzer : public analyzer::Analyzer
+  {
 
-            public:
-                ENIP_UDP_Analyzer(Connection* conn);
-                virtual ~ENIP_UDP_Analyzer();
-                virtual void Done();
+      public:
+          ENIP_UDP_Analyzer(Connection* conn);
+          virtual ~ENIP_UDP_Analyzer();
+          virtual void Done();
 
-                virtual void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen);
-                
-                static analyzer::Analyzer* Instantiate(Connection* conn)
-                { 
-                    return new ENIP_UDP_Analyzer(conn); 
-                }
+          virtual void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen);
 
-            protected:
-                binpac::ENIP::ENIP_Conn* interp;
-                
-        };
-    } 
-}
+          static analyzer::Analyzer* Instantiate(Connection* conn)
+          {
+              return new ENIP_UDP_Analyzer(conn);
+          }
 
-#endif
+      protected:
+          binpac::ENIP::ENIP_Conn* interp;
+
+  };
+} // namespace zeek::analyzer::enip

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,10 +1,10 @@
 // Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
 #include "Plugin.h"
-#include "analyzer/Component.h"
+#include "zeek/analyzer/Component.h"
 
-namespace plugin 
-{ 
-    namespace ICSNPP_ENIP 
+namespace plugin
+{
+    namespace ICSNPP_ENIP
     {
         Plugin plugin;
     }
@@ -12,16 +12,16 @@ namespace plugin
 
 using namespace plugin::ICSNPP_ENIP;
 
-plugin::Configuration Plugin::Configure() 
+zeek::plugin::Configuration Plugin::Configure()
 {
-    AddComponent(new ::analyzer::Component("ENIP_TCP",::analyzer::enip::ENIP_TCP_Analyzer::Instantiate));    
-    AddComponent(new ::analyzer::Component("ENIP_UDP",::analyzer::enip::ENIP_UDP_Analyzer::Instantiate));    
+    AddComponent(new zeek::analyzer::Component("ENIP_TCP",zeek::analyzer::enip::ENIP_TCP_Analyzer::Instantiate));
+    AddComponent(new zeek::analyzer::Component("ENIP_UDP",zeek::analyzer::enip::ENIP_UDP_Analyzer::Instantiate));
 
-    plugin::Configuration config;
+    zeek::plugin::Configuration config;
     config.name = "ICSNPP::ENIP";
     config.description = "Ethernet/IP and CIP Protocol analyzer for TCP/UDP";
     config.version.major = 1;
     config.version.minor = 0;
-    
+
     return config;
 }

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
 #pragma once
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
 #include "ENIP.h"
 
-namespace plugin 
+namespace plugin
 {
-    namespace ICSNPP_ENIP 
+    namespace ICSNPP_ENIP
     {
-        class Plugin : public ::plugin::Plugin 
+        class Plugin : public zeek::plugin::Plugin
         {
             protected:
-                virtual plugin::Configuration Configure();
+                virtual zeek::plugin::Configuration Configure();
         };
 
         extern Plugin plugin;

--- a/src/enip.pac
+++ b/src/enip.pac
@@ -1,5 +1,5 @@
-%include binpac.pac
-%include bro.pac
+%include zeek/binpac.pac
+%include zeek/zeek.pac
 
 %extern{
     #include "events.bif.h"
@@ -10,7 +10,7 @@ analyzer ENIP withcontext {
     flow:       ENIP_Flow;
 };
 
-connection ENIP_Conn(bro_analyzer: BroAnalyzer) {
+connection ENIP_Conn(zeek_analyzer: ZeekAnalyzer) {
     upflow   = ENIP_Flow(true);
     downflow = ENIP_Flow(false);
 };

--- a/zkg.meta
+++ b/zkg.meta
@@ -7,4 +7,4 @@ credits = Stephen Kleinheider <stephen.kleinheider@inl.gov>
 tags =  enip, ENIP, cip, CIP, ics, ICS, CISA, INL, ICSNPP, icsnpp, zeek plugin, log writer, protocol analyzer
 depends =
   zkg >=2.0
-  zeek >=3.0.0
+  zeek >=4.0.0


### PR DESCRIPTION
 Plugin updates for Zeek v4.1.x compatibility

- Rename deprecated (now removed) "bro" references to "zeek"
- Fixed various issues in .cc and .pac files for namespaces, renamed
  types, include file locations, etc.