### PR TITLE
Fix RNG reuse in ENIP generateId()

### DIFF
--- a/src/enip-utilities.pac
+++ b/src/enip-utilities.pac
@@ -35,12 +35,19 @@ enip-analyzer.pac binpac file.
     // The implemenation was taken from: https://lowrey.me/guid-generation-in-c-11/
     //
     std::string generateId() {
+        // Constructed once (function-static) rather than per-iteration:
+        // random_device is a seed source, not a PRNG, and re-seeding a
+        // fresh generator every iteration is both slow (repeated entropy
+        // syscalls) and risks producing identical bytes if random_device
+        // falls back to a deterministic sequence on a given platform.
+        // Zeek's packet-analysis path is single-threaded, so static
+        // (rather than thread_local) is safe here.
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dis(0, 255);
+
         std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
-            // Generate a random char
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_int_distribution<> dis(0, 255);
             const auto rc = dis(gen);
 
             // Hex representaton of random char


### PR DESCRIPTION
Hoist random_device/mt19937/uniform_int_distribution out of the per-byte loop into function-static locals, constructed once instead of on every iteration. Fixes both a perf issue (repeated entropy syscalls) and a correctness risk: random_device may fall back to a deterministic sequence on some platforms, which combined with per-iteration re-seeding could produce identical bytes across the whole ID. Safe as static (not thread_local) since Zeek's packet analysis path is single-threaded.