### PR TITLE
Reassemble TCP-segmented ENIP PDUs in the TCP analyzer

### DIFF
--- a/src/ENIP.cc
+++ b/src/ENIP.cc
@@ -34,32 +34,72 @@ namespace zeek::analyzer::enip {
   {
       analyzer::tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
       assert(TCP());
-      
-      // Commenting out the two lines below to retain ENIP logging when [TCP ACKed unseen segment]
-      // or [TCP Retransmission] packets are sent which results in a TCP gap
-      // if(had_gap)
-      //   return;
 
-      try
+      // ENIP over TCP is length-prefixed: a fixed 24-byte encapsulation header
+      // whose bytes 2-3 (little-endian) give the length of the data that
+      // follows, so a whole PDU is 24 + that length. Zeek reassembles the TCP
+      // stream, but a single PDU can still be split across DeliverStream calls,
+      // and several PDUs can be pipelined into one delivery. The binpac flow
+      // parses each NewData buffer as one complete PDU, so accumulate per
+      // direction and hand it only whole PDUs — otherwise a segment-spanning
+      // PDU parses partially and is dropped (out_of_bound), and any PDU after
+      // the first in a delivery is never seen.
+      std::vector<u_char>& buffer = orig ? orig_buffer : resp_buffer;
+      buffer.insert(buffer.end(), data, data + len);
+      ProcessTCPData(buffer, orig);
+  }
+
+  void ENIP_TCP_Analyzer::ProcessTCPData(std::vector<u_char>& buffer, bool orig)
+  {
+      static constexpr size_t ENIP_HEADER_LEN = 24;
+      // Encapsulation length is a uint16, so a PDU is at most 24 + 0xFFFF.
+      static constexpr size_t ENIP_MAX_PDU_LEN = ENIP_HEADER_LEN + 0xFFFF;
+
+      size_t offset = 0;
+      while ( buffer.size() - offset >= ENIP_HEADER_LEN )
       {
-          interp->NewData(orig, data, data + len);
-      }
-      catch(const binpac::Exception& e)
-      {
-          #if ZEEK_VERSION_NUMBER < 40200
-          ProtocolViolation(util::fmt("Binpac exception: %s", e.c_msg()));
+          const u_char* pdu = buffer.data() + offset;
+          size_t enc_len = pdu[2] | (static_cast<size_t>(pdu[3]) << 8);
+          size_t pdu_len = ENIP_HEADER_LEN + enc_len;
 
-          #else
-          AnalyzerViolation(util::fmt("Binpac exception: %s", e.c_msg()));
+          if ( buffer.size() - offset < pdu_len )
+              break;  // wait for the rest of this PDU
 
-          #endif
+          try
+          {
+              interp->NewData(orig, pdu, pdu + pdu_len);
+          }
+          catch(const binpac::Exception& e)
+          {
+              #if ZEEK_VERSION_NUMBER < 40200
+              ProtocolViolation(util::fmt("Binpac exception: %s", e.c_msg()));
+
+              #else
+              AnalyzerViolation(util::fmt("Binpac exception: %s", e.c_msg()));
+
+              #endif
+          }
+
+          offset += pdu_len;
       }
+
+      if ( offset > 0 )
+          buffer.erase(buffer.begin(), buffer.begin() + offset);
+
+      // Bound memory if we're wedged mid-PDU on an implausible length field
+      // (e.g. non-ENIP traffic on the port); resync on the next header.
+      if ( buffer.size() > ENIP_MAX_PDU_LEN )
+          buffer.clear();
   }
 
   void ENIP_TCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
   {
       analyzer::tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
       had_gap = true;
+      // A TCP gap desynchronizes PDU framing: drop the partial buffer for this
+      // direction so we resync on the next complete header rather than treating
+      // post-gap bytes as a continuation of the pre-gap PDU.
+      (orig ? orig_buffer : resp_buffer).clear();
       interp->NewGap(orig, len);
   }
 

--- a/src/ENIP.h
+++ b/src/ENIP.h
@@ -17,6 +17,9 @@
 
 #include "enip_pac.h"
 
+#include <cstdint>
+#include <vector>
+
 namespace zeek::analyzer::enip {
   class ENIP_TCP_Analyzer : public analyzer::tcp::TCP_ApplicationAnalyzer
   {
@@ -38,6 +41,16 @@ namespace zeek::analyzer::enip {
       protected:
           binpac::ENIP::ENIP_Conn* interp;
           bool had_gap;
+
+          // Reassembly buffers for length-prefixed ENIP-over-TCP framing.
+          // Zeek reassembles the TCP stream, but a single encapsulation PDU
+          // can still span multiple DeliverStream calls (or several PDUs can be
+          // pipelined into one). We accumulate per direction and hand the
+          // (datagram) parser only complete PDUs. See DeliverStream.
+          std::vector<u_char> orig_buffer;
+          std::vector<u_char> resp_buffer;
+
+          void ProcessTCPData(std::vector<u_char>& buffer, bool orig);
   };
 
   class ENIP_UDP_Analyzer : public analyzer::Analyzer


### PR DESCRIPTION
## Problem

The binpac flow parses each `NewData` buffer as one complete ENIP PDU, and
`ENIP_TCP_Analyzer::DeliverStream` forwarded every reassembled TCP stream chunk
to it directly. So a single encapsulation PDU split across TCP segments reached
the parser as a partial buffer, raised a BinPAC `out_of_bound` exception, and was
dropped — no `enip`/`cip` events for that PDU. Any PDU pipelined after the first
in one delivery was likewise never parsed. This silently drops legitimate large
transfers (a CIP request over the path MSS) and lets a client evade inspection
simply by fragmenting the request.

## Fix

ENIP over TCP is length-prefixed: a fixed 24-byte encapsulation header whose
bytes 2-3 (little-endian) give the length of the data that follows, so a whole
PDU is `24 + that length`. Buffer the reassembled stream per direction in the TCP
analyzer and hand the parser only complete PDUs, emitting each pipelined PDU in
turn. A TCP gap clears that direction's buffer so framing resynchronizes on the
next header, and an implausible length can't grow the buffer without bound.

The UDP analyzer and the binpac grammar are unchanged; this is contained to
`ENIP_TCP_Analyzer` (`src/ENIP.cc` / `src/ENIP.h`).

## Validation

Built a Zeek 7.0.6 image with the patched analyzer and replayed a valid CIP
request (Reset, service 0x05, to the Identity object) over TCP/44818 after a
normal 3-way handshake:

- Single segment (control): parses; `enip.log` + `cip.log` produced. Unchanged
  from before.
- The same PDU split across two TCP segments — split at multiple offsets (inside
  the encapsulation header, at the header boundary, in the CPF, deep in the CIP
  payload), split into 4-byte segments, and delivered out of order: **before**
  this change each raises an analyzer violation and produces no `cip.log`;
  **after**, every case reassembles and produces `enip.log` + `cip.log`
  identically to the single-segment control.

Fixes #45.

Note: because pipelined/segmented PDUs are now surfaced (previously dropped), any
analyzer baselines that fed multi-PDU input may show additional, correct output.
